### PR TITLE
chore(#OFAWEB-254): Fix Python 3.12 compatibility by replacing deprec…

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 import importlib
-import imp as _imp
+import importlib.util
 
 
 # autodiscover all documents
@@ -19,9 +19,9 @@ def autodiscover_documents():
         except AttributeError:
             continue
 
-        try:
-            _imp.find_module('documents', pkg_path)
-        except ImportError:
+        # Check if 'documents' module exists in this package
+        spec = importlib.util.find_spec(f'{app}.documents')
+        if spec is None:
             continue
 
         importlib.import_module('{0}.{1}'.format(app, 'documents'))


### PR DESCRIPTION
…ated imp module

The imp module was deprecated in Python 3.4 and removed in Python 3.12. Replace imp.find_module() with importlib.util.find_spec() to check for module existence.

Needed to do it so I can progress with the OFAW-233. 